### PR TITLE
fix: resolve CVE-2026-6321 in fast-uri

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
       "brace-expansion@<1.1.13": "1.1.13",
       "brace-expansion@>=2.0.0 <2.1.0": "2.1.0",
       "brace-expansion@>=3.0.0 <3.0.2": "3.0.2",
-      "brace-expansion@>=4.0.0 <5.0.5": "5.0.5"
+      "brace-expansion@>=4.0.0 <5.0.5": "5.0.5",
+      "fast-uri@<3.1.1": ">=3.1.1"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,6 +13,7 @@ overrides:
   brace-expansion@>=2.0.0 <2.1.0: 2.1.0
   brace-expansion@>=3.0.0 <3.0.2: 3.0.2
   brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  fast-uri@<3.1.1: '>=3.1.1'
 
 importers:
 
@@ -1743,8 +1744,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.0:
-    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -3828,7 +3829,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.0
+      fast-uri: 3.1.2
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4574,7 +4575,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.0: {}
+  fast-uri@3.1.2: {}
 
   fastq@1.19.1:
     dependencies:


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability CVE-2026-6321 in `fast-uri`.

**Advisory**: fast-uri vulnerable to path traversal via percent-encoded dot segments
**Vulnerable versions**: <=3.1.0
**Patched versions**: >=3.1.1
**Advisory URL**: https://github.com/advisories/GHSA-q3j6-qgpj-74h6

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes CVE-2026-6321: _fast-uri vulnerable to path traversal via percent-encoded dot segments_

### How to test this PR?

Run `pnpm audit` and verify CVE-2026-6321 is no longer reported