### PR TITLE
chore: add repository/homepage fields to extension package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,7 @@
 {
   "name": "apple-container",
+  "repository": "https://github.com/podman-desktop/extension-apple-container",
+  "homepage": "https://github.com/podman-desktop/extension-apple-container#readme",
   "displayName": "Apple container",
   "description": "List/Manage Apple containers on macOS",
   "version": "0.2.0-next",


### PR DESCRIPTION
## Summary
- add missing `homepage` field in extension `package.json`
- ensure both `repository` and `homepage` point to the canonical GitHub repo URL
- closes #301

## Test plan
- [x] verify `package.json` contains both `repository` and `homepage`
- [x] run `git diff main...HEAD` and confirm only metadata change is included

Made with [Cursor](https://cursor.com)