### PR TITLE
chore(pnpm): bump to v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,22 +64,5 @@
     "vite": "8.2.1",
     "vitest": "^4.1.10"
   },
-  "packageManager": "pnpm@10.7.1+sha512.2d92c86b7928dc8284f53494fb4201f983da65f0fb4f0d40baafa5cf628fa31dae3e5968f12466f17df7e97310e30f343a648baea1b9b350685dafafffdf5808",
-  "pnpm": {
-    "overrides": {
-      "minimatch@<3.1.3": ">=3.1.3",
-      "minimatch@>=9.0.0 <9.0.9": "9.0.9",
-      "picomatch@>=4.0.0 <4.0.4": ">=4.0.4",
-      "yaml@>=2.0.0 <2.8.3": ">=2.8.3",
-      "brace-expansion@<1.1.16": "1.1.16",
-      "brace-expansion@>=2.0.0 <2.1.2": "2.1.2",
-      "brace-expansion@>=3.0.0 <3.0.2": "3.0.2",
-      "brace-expansion@>=4.0.0 <5.0.5": "5.0.5",
-      "fast-uri@<3.1.4": "3.1.4",
-      "fast-uri@>=4.0.0 <=4.1.0": "4.1.1",
-      "shell-quote@>=1.1.0 <=1.8.4": ">=1.9.0",
-      "esbuild@>=0.17.0 <0.28.1": ">=0.28.1",
-      "js-yaml@<=4.1.1": ">=4.2.0"
-    }
-  }
+  "packageManager": "pnpm@11.22.0+sha512.1ff870c4c6133dfd88fb2afc46dd13d47f09c9794b438c6fdb47ca98caf3bc16381ee0be93a091b8e3824cf01f889f46d7d9e20910fb0be1ab0fb5baa80dd621"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,17 @@
+allowBuilds:
+  esbuild: true
+  unrs-resolver: true
+overrides:
+  minimatch@<3.1.3: '>=3.1.3'
+  minimatch@>=9.0.0 <9.0.9: 9.0.9
+  picomatch@>=4.0.0 <4.0.4: '>=4.0.4'
+  yaml@>=2.0.0 <2.8.3: '>=2.8.3'
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
+  brace-expansion@>=3.0.0 <3.0.2: 3.0.2
+  brace-expansion@>=4.0.0 <5.0.5: 5.0.5
+  fast-uri@<3.1.4: 3.1.4
+  fast-uri@>=4.0.0 <=4.1.0: 4.1.1
+  shell-quote@>=1.1.0 <=1.8.4: '>=1.9.0'
+  esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
+  js-yaml@<=4.1.1: '>=4.2.0'


### PR DESCRIPTION
### What does this PR do?

Bumping pnpm to v11. I ran the migration script provided `pnpx codemod run pnpm-v10-to-v11`[^1]

[^1]: https://pnpm.io/migration

### What issues does this PR fix or reference?

Same as https://github.com/podman-desktop/podman-desktop/issues/17794

### How to test this PR?

<!-- Please explain steps to verify the functionality,
do not forget to provide unit/component tests -->

- CI should be :green_circle: 
