### PR TITLE
fix: resolve GHSA-7p8r-x3mc-p8w7 in fast-uri

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ overrides:
   brace-expansion@^1: 1.1.18
   brace-expansion@^2: 2.1.4
   brace-expansion@^5: 5.0.9
-  fast-uri@<3.1.4: 3.1.4
+  fast-uri@<3.1.5: '>=3.1.5 <4'
   fast-uri@>=4.0.0 <=4.1.0: 4.1.1
   shell-quote@>=1.1.0 <=1.8.4: '>=1.9.0'
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'
@@ -1601,8 +1601,8 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -3603,7 +3603,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4309,7 +4309,7 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
   fastq@1.19.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,7 +9,7 @@ overrides:
   brace-expansion@^1: 1.1.18
   brace-expansion@^2: 2.1.4
   brace-expansion@^5: 5.0.9
-  fast-uri@<3.1.4: 3.1.4
+  fast-uri@<3.1.5: '>=3.1.5 <4'
   fast-uri@>=4.0.0 <=4.1.0: 4.1.1
   shell-quote@>=1.1.0 <=1.8.4: '>=1.9.0'
   esbuild@>=0.17.0 <0.28.1: '>=0.28.1'


### PR DESCRIPTION
### What does this PR do?

Fix high severity vulnerability GHSA-7p8r-x3mc-p8w7 in `fast-uri`.

**Advisory**: fast-uri vulnerable to host confusion via backslash authority introducer
**Vulnerable versions**: >=3.0.0 <3.1.5
**Patched versions**: >=3.1.5
**Advisory URL**: https://github.com/advisories/GHSA-7p8r-x3mc-p8w7

### Screenshot / video of UI

N/A - dependency update only.

### What issues does this PR fix or reference?

Fixes GHSA-7p8r-x3mc-p8w7: _fast-uri vulnerable to host confusion via backslash authority introducer_

### How to test this PR?

Run `pnpm audit` and verify GHSA-7p8r-x3mc-p8w7 is no longer reported